### PR TITLE
Add fixtures for `wp_send_json*` and `is_wp_error` functions

### DIFF
--- a/fixtures.php
+++ b/fixtures.php
@@ -29,4 +29,43 @@ $fixtures['$global']['functions']['do_action'] = <<<'PHP'
 function do_action($hook_name, ...$args) {};
 PHP;
 
+$fixtures['$global']['functions']['wp_send_json'] = <<<'PHP'
+/**
+ * @param mixed $response
+ * @param int|null $status_code
+ * @param int $options
+ * @psalm-return never
+*/
+function wp_send_json($response, $status_code = null, $options = 0) {};
+PHP;
+
+$fixtures['$global']['functions']['wp_send_json_success'] = <<<'PHP'
+/**
+ * @param mixed $data
+ * @param int|null $status_code
+ * @param int $options
+ * @psalm-return never
+*/
+function wp_send_json_success( $data = null, $status_code = null, $options = 0 ) {};
+PHP;
+
+$fixtures['$global']['functions']['wp_send_json_error'] = <<<'PHP'
+/**
+ * @param mixed $data
+ * @param int|null $status_code
+ * @param int $options
+ * @psalm-return never
+*/
+function wp_send_json_error( $data = null, $status_code = null, $options = 0 ) {};
+PHP;
+
+$fixtures['$global']['functions']['is_wp_error'] = <<<'PHP'
+/**
+ * @param mixed $thing
+ * @return bool
+ * @psalm-assert-if-true \WP_Error $thing
+*/
+function is_wp_error( $thing ) {};
+PHP;
+
 return $fixtures;

--- a/fixtures.php
+++ b/fixtures.php
@@ -46,7 +46,7 @@ $fixtures['$global']['functions']['wp_send_json_success'] = <<<'PHP'
  * @param int $options
  * @psalm-return never
 */
-function wp_send_json_success( $data = null, $status_code = null, $options = 0 ) {};
+function wp_send_json_success($data = null, $status_code = null, $options = 0) {};
 PHP;
 
 $fixtures['$global']['functions']['wp_send_json_error'] = <<<'PHP'
@@ -56,7 +56,7 @@ $fixtures['$global']['functions']['wp_send_json_error'] = <<<'PHP'
  * @param int $options
  * @psalm-return never
 */
-function wp_send_json_error( $data = null, $status_code = null, $options = 0 ) {};
+function wp_send_json_error($data = null, $status_code = null, $options = 0) {};
 PHP;
 
 $fixtures['$global']['functions']['is_wp_error'] = <<<'PHP'
@@ -65,7 +65,7 @@ $fixtures['$global']['functions']['is_wp_error'] = <<<'PHP'
  * @return bool
  * @psalm-assert-if-true \WP_Error $thing
 */
-function is_wp_error( $thing ) {};
+function is_wp_error($thing) {};
 PHP;
 
 return $fixtures;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature.


**What is the current behavior?** (You can also link to an open issue here)
The generated by default annotation is incomplete.


**What is the new behavior (if this is a feature change)?**
Added `return never` for `wp_send_json*` functions and assertion for `is_wp_error` function.

Usage example - https://psalm.dev/r/ee7baa7900.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.



**Other information**:
