### PR TITLE
Add Composer `branch-alias`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,5 +29,8 @@
     "minimum-stability": "dev",
     "extra": {
         "installer-disable": true
+    },
+    "branch-alias": {
+       "dev-main": "1.0.x-dev"
     }
 }


### PR DESCRIPTION
Allow project with a non `minimum-stability` set to `dev` to require the package

