### PR TITLE
Add wp_die fixture

### DIFF
--- a/fixtures.php
+++ b/fixtures.php
@@ -29,13 +29,24 @@ $fixtures['$global']['functions']['do_action'] = <<<'PHP'
 function do_action($hook_name, ...$args) {};
 PHP;
 
+$fixtures['$global']['functions']['wp_die'] = <<<'PHP'
+/**
+ * @template T
+ * @param string|WP_Error $message
+ * @param string|int $title
+ * @param string|array{exit?: T}|int $args
+ * @psalm-return (T is null|true ? never : void)
+ */
+function wp_die($message = '', $title = '', $args = []) {};
+PHP;
+
 $fixtures['$global']['functions']['wp_send_json'] = <<<'PHP'
 /**
  * @param mixed $response
  * @param int|null $status_code
  * @param int $options
  * @psalm-return never
-*/
+ */
 function wp_send_json($response, $status_code = null, $options = 0) {};
 PHP;
 
@@ -45,7 +56,7 @@ $fixtures['$global']['functions']['wp_send_json_success'] = <<<'PHP'
  * @param int|null $status_code
  * @param int $options
  * @psalm-return never
-*/
+ */
 function wp_send_json_success($data = null, $status_code = null, $options = 0) {};
 PHP;
 
@@ -55,7 +66,7 @@ $fixtures['$global']['functions']['wp_send_json_error'] = <<<'PHP'
  * @param int|null $status_code
  * @param int $options
  * @psalm-return never
-*/
+ */
 function wp_send_json_error($data = null, $status_code = null, $options = 0) {};
 PHP;
 
@@ -64,7 +75,7 @@ $fixtures['$global']['functions']['is_wp_error'] = <<<'PHP'
  * @param mixed $thing
  * @return bool
  * @psalm-assert-if-true \WP_Error $thing
-*/
+ */
 function is_wp_error($thing) {};
 PHP;
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Add a custom fixture for the `wp_die` function.

**What is the current behavior?** (You can also link to an open issue here)

Psalm does not acknowledge that the `wp_die` function will call `exit`, unless the optional `$args['exit']` flag is explicitly set to a falsy value.

**What is the new behavior (if this is a feature change)?**

For the `wp_die` function, Psalm expects an internal return type `never` unless the optional `$args['exit']` flag is explicitly set to a falsy value, in which case Psalm expects a `void` return type.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

**Other information**:

There are several (private-ish) functions related to `wp_die`, for example, `_ajax_wp_die_handler`. If we wanted, we could also add fixures for these.