### PR TITLE
fix: update dist references in Composer repository

### DIFF
--- a/.github/workflows/build-stubs.yml
+++ b/.github/workflows/build-stubs.yml
@@ -44,5 +44,12 @@ jobs:
                     git config --add safe.directory "${GITHUB_WORKSPACE}"
                     git add ./stubs/*
                     git add ./packages.json
-                    git commit -m "Update WordPress stubs" || echo 'Nothing to commit'
+                    git commit -m "Update WordPress stubs" || ((echo "NO_CHANGES=yes" >> $GITHUB_ENV) && (echo "No changes to commit"))
+
+            -   name: Update reference and push
+                if: ${{ env.NO_CHANGES != 'yes' }}
+                run: |
+                    php update_reference.php "$(git rev-parse HEAD)"
+                    git add ./packages.json
+                    git commit -m "Update packages.json references"
                     git push

--- a/inc/process.php
+++ b/inc/process.php
@@ -136,8 +136,8 @@ function buildComposerRepo(string $targetDir, string $reference = 'main'): bool
     $finder = Finder::create()->in("{$targetDir}/stubs")
         ->files()
         ->name('*.php')
-        ->sortByModifiedTime()
-        ->reverseSorting();
+        ->sort(\Closure::fromCallable(__NAMESPACE__ . '\\sortByVersionDesc'));
+
     $basePackage = [
         'name' => VERSIONED_PACKAGE_NAME,
         'version' => '',
@@ -156,6 +156,21 @@ function buildComposerRepo(string $targetDir, string $reference = 'main'): bool
     }
 
     return writeComposerRepo($data, "{$targetDir}/packages.json");
+}
+
+function sortByVersionDesc(\SplFileInfo $a, \SplFileInfo $b): int
+{
+    $aBaseName = $a->getBasename('.php');
+    if ($aBaseName === 'latest') {
+        return -1;
+    }
+
+    $bBaseName = $b->getBasename('.php');
+    if ($bBaseName === 'latest') {
+        return 1;
+    }
+
+    return version_compare($bBaseName, $aBaseName);
 }
 
 /**

--- a/inc/process.php
+++ b/inc/process.php
@@ -127,9 +127,10 @@ function writeOutput(string $output, string $targetPath, string $version): bool
 
 /**
  * @param string $targetDir
+ * @param string $reference
  * @return bool
  */
-function buildComposerRepo(string $targetDir): bool
+function buildComposerRepo(string $targetDir, string $reference = 'main'): bool
 {
     $data = ['packages' => [VERSIONED_PACKAGE_NAME => []]];
     $finder = Finder::create()->in("{$targetDir}/stubs")
@@ -141,15 +142,16 @@ function buildComposerRepo(string $targetDir): bool
         'name' => VERSIONED_PACKAGE_NAME,
         'version' => '',
         'dist' => [
-            'url' => 'https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/%s.php',
+            'url' => 'https://raw.githubusercontent.com/inpsyde/wp-stubs/%s/stubs/%s.php',
             'type' => 'file',
+            'reference' => $reference,
         ],
     ];
     foreach ($finder as $file) {
         $basename = $file->getBasename('.php');
         $package = $basePackage;
         $package['version'] = ($basename === 'latest') ? 'dev-latest' : $basename;
-        $package['dist']['url'] = sprintf($package['dist']['url'], $basename);
+        $package['dist']['url'] = sprintf($package['dist']['url'], $reference, $basename);
         $data['packages'][VERSIONED_PACKAGE_NAME][] = $package;
     }
 

--- a/packages.json
+++ b/packages.json
@@ -5,576 +5,648 @@
                 "name": "inpsyde/wp-stubs-versions",
                 "version": "dev-latest",
                 "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/latest.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "6.6",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/6.6.php",
-                    "type": "file"
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/latest.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
                 }
             },
             {
                 "name": "inpsyde/wp-stubs-versions",
                 "version": "6.6.1",
                 "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/6.6.1.php",
-                    "type": "file"
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/6.6.1.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
                 }
             },
             {
                 "name": "inpsyde/wp-stubs-versions",
-                "version": "6.5.4",
+                "version": "6.6",
                 "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/6.5.4.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "5.0",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/5.0.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "5.3.17",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/5.3.17.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "6.4.5",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/6.4.5.php",
-                    "type": "file"
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/6.6.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
                 }
             },
             {
                 "name": "inpsyde/wp-stubs-versions",
                 "version": "6.5.5",
                 "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/6.5.5.php",
-                    "type": "file"
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/6.5.5.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
                 }
             },
             {
                 "name": "inpsyde/wp-stubs-versions",
-                "version": "5.7.11",
+                "version": "6.5.4",
                 "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/5.7.11.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "6.2",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/6.2.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "5.1",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/5.1.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "6.0.7",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/6.0.7.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "5.3.18",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/5.3.18.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "5.2.20",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/5.2.20.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "6.2.4",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/6.2.4.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "6.0.9",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/6.0.9.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "6.3.5",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/6.3.5.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "5.5.15",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/5.5.15.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "6.4.4",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/6.4.4.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "5.8.10",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/5.8.10.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "5.6",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/5.6.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "5.8.9",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/5.8.9.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "5.8",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/5.8.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "6.3",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/6.3.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "6.1.5",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/6.1.5.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "6.0.8",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/6.0.8.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "5.2.21",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/5.2.21.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "5.6.13",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/5.6.13.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "5.9.9",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/5.9.9.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "5.1.19",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/5.1.19.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "6.1",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/6.1.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "5.6.14",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/5.6.14.php",
-                    "type": "file"
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/6.5.4.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
                 }
             },
             {
                 "name": "inpsyde/wp-stubs-versions",
                 "version": "6.5.3",
                 "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/6.5.3.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "5.2",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/5.2.php",
-                    "type": "file"
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/6.5.3.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
                 }
             },
             {
                 "name": "inpsyde/wp-stubs-versions",
                 "version": "6.5.2",
                 "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/6.5.2.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "5.1.18",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/5.1.18.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "5.4.16",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/5.4.16.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "6.3.4",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/6.3.4.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "5.4.15",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/5.4.15.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "6.4",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/6.4.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "6.4.3",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/6.4.3.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "5.7.12",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/5.7.12.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "5.9",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/5.9.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "6.3.3",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/6.3.3.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "5.9.10",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/5.9.10.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "6.2.5",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/6.2.5.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "5.3",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/5.3.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "5.7",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/5.7.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "6.2.6",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/6.2.6.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "6.0",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/6.0.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "6.1.7",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/6.1.7.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "5.4",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/5.4.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "5.5.14",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/5.5.14.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "6.1.6",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/6.1.6.php",
-                    "type": "file"
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/6.5.2.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
                 }
             },
             {
                 "name": "inpsyde/wp-stubs-versions",
                 "version": "6.5",
                 "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/6.5.php",
-                    "type": "file"
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/6.5.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "6.4.5",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/6.4.5.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "6.4.4",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/6.4.4.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "6.4.3",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/6.4.3.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "6.4",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/6.4.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "6.3.5",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/6.3.5.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "6.3.4",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/6.3.4.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "6.3.3",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/6.3.3.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "6.3",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/6.3.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "6.2.6",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/6.2.6.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "6.2.5",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/6.2.5.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "6.2.4",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/6.2.4.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "6.2",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/6.2.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "6.1.7",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/6.1.7.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "6.1.6",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/6.1.6.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "6.1.5",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/6.1.5.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "6.1",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/6.1.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "6.0.9",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/6.0.9.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "6.0.8",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/6.0.8.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "6.0.7",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/6.0.7.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "6.0",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/6.0.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "5.9.10",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/5.9.10.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "5.9.9",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/5.9.9.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "5.9",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/5.9.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "5.8.10",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/5.8.10.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "5.8.9",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/5.8.9.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "5.8",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/5.8.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "5.7.12",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/5.7.12.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "5.7.11",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/5.7.11.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "5.7",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/5.7.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "5.6.14",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/5.6.14.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "5.6.13",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/5.6.13.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "5.6",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/5.6.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "5.5.15",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/5.5.15.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "5.5.14",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/5.5.14.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
                 }
             },
             {
                 "name": "inpsyde/wp-stubs-versions",
                 "version": "5.5",
                 "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/5.5.php",
-                    "type": "file"
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/5.5.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
                 }
             },
             {
                 "name": "inpsyde/wp-stubs-versions",
-                "version": "4.6.28",
+                "version": "5.4.16",
                 "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/4.6.28.php",
-                    "type": "file"
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/5.4.16.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
                 }
             },
             {
                 "name": "inpsyde/wp-stubs-versions",
-                "version": "4.7",
+                "version": "5.4.15",
                 "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/4.7.php",
-                    "type": "file"
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/5.4.15.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
                 }
             },
             {
                 "name": "inpsyde/wp-stubs-versions",
-                "version": "4.5.31",
+                "version": "5.4",
                 "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/4.5.31.php",
-                    "type": "file"
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/5.4.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
                 }
             },
             {
                 "name": "inpsyde/wp-stubs-versions",
-                "version": "4.5",
+                "version": "5.3.18",
                 "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/4.5.php",
-                    "type": "file"
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/5.3.18.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "5.3.17",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/5.3.17.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "5.3",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/5.3.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "5.2.21",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/5.2.21.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "5.2.20",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/5.2.20.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "5.2",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/5.2.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "5.1.19",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/5.1.19.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "5.1.18",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/5.1.18.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "5.1",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/5.1.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
                 }
             },
             {
                 "name": "inpsyde/wp-stubs-versions",
                 "version": "5.0.22",
                 "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/5.0.22.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "4.8.25",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/4.8.25.php",
-                    "type": "file"
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/5.0.22.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
                 }
             },
             {
                 "name": "inpsyde/wp-stubs-versions",
                 "version": "5.0.21",
                 "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/5.0.21.php",
-                    "type": "file"
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/5.0.21.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "5.0",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/5.0.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
                 }
             },
             {
                 "name": "inpsyde/wp-stubs-versions",
                 "version": "4.9.26",
                 "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/4.9.26.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "4.7.28",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/4.7.28.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "4.8",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/4.8.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "4.8.24",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/4.8.24.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "4.6.29",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/4.6.29.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "4.6",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/4.6.php",
-                    "type": "file"
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/4.9.26.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
                 }
             },
             {
                 "name": "inpsyde/wp-stubs-versions",
                 "version": "4.9.25",
                 "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/4.9.25.php",
-                    "type": "file"
-                }
-            },
-            {
-                "name": "inpsyde/wp-stubs-versions",
-                "version": "4.7.29",
-                "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/4.7.29.php",
-                    "type": "file"
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/4.9.25.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
                 }
             },
             {
                 "name": "inpsyde/wp-stubs-versions",
                 "version": "4.9",
                 "dist": {
-                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/main/stubs/4.9.php",
-                    "type": "file"
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/4.9.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "4.8.25",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/4.8.25.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "4.8.24",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/4.8.24.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "4.8",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/4.8.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "4.7.29",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/4.7.29.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "4.7.28",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/4.7.28.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "4.7",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/4.7.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "4.6.29",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/4.6.29.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "4.6.28",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/4.6.28.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "4.6",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/4.6.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "4.5.31",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/4.5.31.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
+                }
+            },
+            {
+                "name": "inpsyde/wp-stubs-versions",
+                "version": "4.5",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/inpsyde/wp-stubs/fc42bf68823bba8a7c05151b6ea8b6582bfae92d/stubs/4.5.php",
+                    "type": "file",
+                    "reference": "fc42bf68823bba8a7c05151b6ea8b6582bfae92d"
                 }
             }
         ]

--- a/update_reference.php
+++ b/update_reference.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Inpsyde\WpStubs;
+
+const WP_STUBS_DIR = __DIR__;
+
+try {
+    if (!is_file(WP_STUBS_DIR . '/vendor/autoload.php')) {
+        throw new \Error("Please install via Composer first.");
+    }
+    require_once 'vendor/autoload.php';
+
+    $commitHash = filter_var((string)($argv[1] ?? ''), FILTER_SANITIZE_SPECIAL_CHARS);
+    if (!isValid($commitHash)) {
+        throw new \Error('Invalid commit hash');
+    }
+
+    $repoBuilt = buildComposerRepo(__DIR__, $commitHash);
+
+    if ($repoBuilt) {
+        fwrite(STDOUT, "\nReferences updated.\n");
+        exit(0);
+    }
+
+    fwrite(STDERR, "\nReferences updating failed.\n");
+    exit(1);
+} catch (\Throwable $throwable) {
+    function_exists(__NAMESPACE__ . '\\describeFailure')
+        ? describeFailure($throwable)
+        : fwrite(STDERR, sprintf("\n%s\n", $throwable->getMessage()));
+    exit(1);
+}
+
+function isValid(string $commitHash): bool
+{
+    return preg_match('/^[0-9a-f]{40}$/', $commitHash) === 1;
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix.


**What is the current behavior?** (You can also link to an open issue here)
https://github.com/inpsyde/wp-stubs/issues/9


**What is the new behavior (if this is a feature change)?**
Dist URLs contain references.
Items in `package.json` are always ordered by version from newest to previous.
The `package.json` was rebuilt locally.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


**Other information**:
