### PR TITLE
feat: rebuild stubs if fixtures were changed

### DIFF
--- a/.github/workflows/build-stubs.yml
+++ b/.github/workflows/build-stubs.yml
@@ -4,6 +4,11 @@ on:
     schedule:
       - cron: '0 0 * * *'
     workflow_dispatch:
+    push:
+        branches:
+            - main
+        paths:
+            - 'fixtures.php'
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature.


**What is the current behavior?** (You can also link to an open issue here)
We have to rebuild stubs if we change fixtures manually.


**What is the new behavior (if this is a feature change)?**
The rebuild happens automatically.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


**Other information**:
We might consider to include all generation-related code into `paths`, but it might not be so safe. Because if build logic is changed maybe we don't want to rebuild everything immediately to avoid side-effects. Or PR can contain all changes already. But `fixtures.php` is really source code so it always requires rebuilding.
