### PR TITLE
Add custom fixtures for esc_sql and wp_parse_url

### DIFF
--- a/fixtures.php
+++ b/fixtures.php
@@ -101,4 +101,21 @@ $fixtures['$global']['functions']['get_taxonomies'] = <<<'PHP'
 function get_taxonomies( $args = array(), $output = 'names', $operator = 'and' ) {};
 PHP;
 
+$fixtures['$global']['functions']['esc_sql'] = <<<'PHP'
+/**
+ * @param string|array $data
+ * @return ($data is string ? string : array)
+ */
+function esc_sql( $data ) {};
+PHP;
+
+$fixtures['$global']['functions']['wp_parse_url'] = <<<'PHP'
+/**
+ * @param string $url
+ * @param int $component
+ * @return ($component is -1 ? false|array<string|int> : false|null|string|int)
+ */
+function wp_parse_url( $url, $component = -1 ) {};
+PHP;
+
 return $fixtures;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR adds two custom fixtures with improved type information.

**What is the current behavior?** (You can also link to an open issue here)

The `esc_sql` function is currently defined like so:

```php
/*
 * @param string|array
 * @return string|array
 */
function esc_sql($data) {}
```

The `esc_sql` function is currently defined like so:

```php
/*
 * @param string $url
 * @param int $component
 * @return mixed
 */
function wp_parse_url($url, $component = -1) {}
```

**What is the new behavior (if this is a feature change)?**

For the above two functions, the return type is inferred based on one of the parameters, leading to more narrow type declaration.

```php
/**
 * @param string|array $data
 * @return ($data is string ? string : array)
 */
function esc_sql( $data ) {};

/**
 * @param string $url
 * @param int $component
 * @return ($component is -1 ? false|array<string|int> : false|null|string|int)
 */
function wp_parse_url( $url, $component = -1 ) {};
```

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

**Other information**:
